### PR TITLE
[feat]: add current_sequence_id in status messages

### DIFF
--- a/msg/RMSStatus.msg
+++ b/msg/RMSStatus.msg
@@ -4,5 +4,6 @@ string MODE_AUTO = auto
 StateMachineStatus state_machine
 string current_poi
 string mode
+string current_sequence_id
 string current_sequence
 string[] queue

--- a/package.xml
+++ b/package.xml
@@ -1,19 +1,19 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>robot_rms_msgs</name>
-  <version>0.0.0</version>
+  <version>0.1.0</version>
   <description>The robot_rms_msgs package</description>
 
   <!-- One maintainer tag required, multiple allowed, one person per tag -->
   <!-- Example:  -->
   <!-- <maintainer email="jane.doe@example.com">Jane Doe</maintainer> -->
   <maintainer email="aarnal@robotnik.es">Alejandro Arnal Espinola</maintainer>
-
+  <maintainer email="msanchez@robotnik.es">Miguel Sánchez</maintainer>
 
   <!-- One license tag required, multiple allowed, one license per tag -->
   <!-- Commonly used license strings: -->
   <!--   BSD, MIT, Boost Software License, GPLv2, GPLv3, LGPLv2.1, LGPLv3 -->
-  <license>TODO</license>
+  <license>BSD</license>
 
 
   <!-- Url tags are optional, but multiple are allowed, one per tag -->


### PR DESCRIPTION
This pull request introduces a new field, `current_sequence_id`, to the `msg/RMSStatus.msg` file to enhance the tracking of sequences in the system.

Key change:

* Added a new `string current_sequence_id` field to the `RMSStatus.msg` message definition to uniquely identify the current sequence being processed.